### PR TITLE
Reconcile fleet runtime and enforce installed Ops Agent version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Ops Agent convergence now checks the installed package status and version,
+  repairs drift even when the version marker is stale, and verifies package
+  installation before recording success. Missing or stale markers on a
+  correct installation are repaired without reinstalling or restarting it.
+  The example configuration now pins Ops Agent 2.70.0.
+
 ### Added
 
 - Claude Fable 5.1 (`global.anthropic.claude-fable-5-1[1m]`) as the fleet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Claude Fable 5.1 (`global.anthropic.claude-fable-5-1[1m]`) as the fleet
+  Bedrock default, with Fable 5 retained in bclaude's `/model` picker. The
+  runtime now requires Claude Code 2.1.255 or newer and uses the authorized
+  Bedrock Runtime inference-profile route instead of Mantle. Paseo versions
+  supporting live reload apply this provider configuration without restarting
+  the daemon or active agents; older versions retain restart-based updates.
+  Package convergence now also defers `paseo.service` in Ubuntu `needrestart`.
 - Claude Sonnet 5 (`global.anthropic.claude-sonnet-5[1m]`) in the fleet
   Bedrock defaults: offered in bclaude's `/model` picker and Paseo's
   Claude (Bedrock) provider, and pinned as Claude Code's "sonnet" alias via
@@ -22,9 +29,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   vendor origins without a sha pin: pins were tried and removed the same day
   because the URLs float, so every legitimate installer update broke the
   repair/bootstrap path until an admin re-pinned.
-- Codex Superpowers now installs from Codex's preconfigured official
-  marketplace (`openai-curated`, github.com/openai/plugins) instead of the
-  plugin author's personal repository.
+- Codex Superpowers now installs from Codex's authenticated official
+  marketplace (`openai-curated`) instead of the plugin author's personal
+  repository. Logged-out bootstrap runs defer this step without failing
+  convergence and retry automatically after the developer signs in.
 
 ## [0.1.0] — 2026-08-10
 

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -376,7 +376,7 @@ above for the policy note) — install.sh's own manifest check shares an origin
 with the binary it fetches, so it is transport protection, not provenance.
 
 That marker is a cache of a live contract check (regular file, dev-owned,
-executable, non-empty `--version`), recomputed every converge and **deleted
+executable, version 2.1.255 or newer), recomputed every converge and **deleted
 before any repair attempt**. So an absent marker means claude is currently
 broken on that box, and three things deliberately stop: the old-install
 cleanup, the agent-plugins concern, and every Bedrock-side action in
@@ -401,8 +401,13 @@ cleanup removes the nvm package directory but leaves that symlink dangling
 (a known, accepted defect). The package behind it is gone and the entry is
 harmless — do not escalate on its presence alone.
 
-`paseo provider ls` shows `bclaude` only after the daemon reloads the updated
-config. Use `sudo systemctl restart paseo` when an immediate reload is wanted.
+`paseo provider ls` shows `bclaude` after the daemon reloads the updated
+config. Convergence runs `paseo reload --json` automatically when the
+installed CLI supports it, including when the config file is unchanged.
+This keeps active agents running. Older CLIs such as the supported 0.4
+bootstrap pin lack `reload`; convergence warns that their provider changes
+take effect on the next daemon restart. Use `sudo systemctl restart paseo`
+for those versions when an immediate update is needed.
 
 ## Day-2 changes to `devbox-onboard` (no rebuild)
 

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -36,7 +36,7 @@ toolchain = {
   # tmux_continuum_commit     = "0698e8f4b17d6454c71bf5212895ec055c578da0"
 }
 
-ops_agent_version = "2.55.0"
+ops_agent_version = "2.70.0"
 
 # New or rebuilt machines get a 120 GB root disk by default. Terraform
 # intentionally ignores root-disk size after creation; use root_disk_gb on a

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -105,7 +105,7 @@ variable "toolchain" {
 }
 
 variable "ops_agent_version" {
-  description = "Pinned google-cloud-ops-agent apt package version (e.g. 2.55.0). Delivered via manifest; converged by scripts/gcp/devbox-observability."
+  description = "Pinned google-cloud-ops-agent apt package version (e.g. 2.70.0). Delivered via manifest; checked against the installed package by scripts/gcp/devbox-observability."
   type        = string
 }
 

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -418,14 +418,11 @@ variable "bedrock_model_env" {
   description = "Model/config env delivered as one `env` assignment per key rendered into /usr/local/bin/bclaude, between the AWS_REGION and CLAUDE_CODE_USE_BEDROCK assignments the concern always sets. Must not include a credential selector (AWS_PROFILE, AWS_DEFAULT_PROFILE, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_SECURITY_TOKEN, AWS_CREDENTIAL_EXPIRATION, AWS_BEARER_TOKEN_BEDROCK): the wrapper strips those via `env -u` earlier on the same command line, and setting one here would re-set it right back, silently routing Bedrock traffic as the wrong principal or aborting Claude Code's credential chain outright (AWS_PROFILE verified on-box, 2.1.207). devbox-bedrock-config fails loudly if this map contains one."
   type        = map(string)
   default = {
-    CLAUDE_CODE_USE_MANTLE   = "1"
     ENABLE_PROMPT_CACHING_1H = "1"
-    # Bare model ID: works under Mantle (CLAUDE_CODE_USE_MANTLE=1); without
-    # Mantle, on-demand invocation rejects it ("use an inference profile"
-    # 400 from Bedrock). The DEFAULT_* pins keep the global.* form. Claude
+    # Use the global inference profiles authorized by aws-federation. Claude
     # Code strips the [1m] capability suffix before calling Bedrock.
-    ANTHROPIC_MODEL                = "anthropic.claude-fable-5[1m]"
-    ANTHROPIC_DEFAULT_FABLE_MODEL  = "global.anthropic.claude-fable-5[1m]"
+    ANTHROPIC_MODEL                = "global.anthropic.claude-fable-5-1[1m]"
+    ANTHROPIC_DEFAULT_FABLE_MODEL  = "global.anthropic.claude-fable-5-1[1m]"
     ANTHROPIC_DEFAULT_OPUS_MODEL   = "global.anthropic.claude-opus-5[1m]"
     ANTHROPIC_DEFAULT_SONNET_MODEL = "global.anthropic.claude-sonnet-5[1m]"
     ANTHROPIC_DEFAULT_HAIKU_MODEL  = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -436,7 +433,7 @@ variable "bedrock_available_models" {
   description = "Model IDs offered in bclaude's /model picker — rendered as a --settings availableModels JSON on the claude invocation. Empty list omits the flag."
   type        = list(string)
   default = [
-    "anthropic.claude-fable-5[1m]",
+    "global.anthropic.claude-fable-5-1[1m]",
     "global.anthropic.claude-fable-5[1m]",
     "global.anthropic.claude-opus-5[1m]",
     "global.anthropic.claude-sonnet-5[1m]",

--- a/scripts/devbox-toolchain
+++ b/scripts/devbox-toolchain
@@ -36,6 +36,7 @@ PASEO_CONFIG_DIR="${DEVBOX_PASEO_CONFIG_DIR:-$DEV_HOME/.paseo}"
 PASEO_CONFIG_FILE="${DEVBOX_PASEO_CONFIG_FILE:-$PASEO_CONFIG_DIR/config.json}"
 PASEO_DAEMON_RUNNER="${DEVBOX_PASEO_DAEMON_RUNNER:-/usr/local/bin/devbox-paseo-daemon}"
 PASEO_DAEMON_SERVICE_FILE="${DEVBOX_PASEO_DAEMON_SERVICE_FILE:-/etc/systemd/system/paseo.service}"
+NEEDRESTART_PASEO_CONFIG_FILE="${DEVBOX_NEEDRESTART_PASEO_CONFIG_FILE:-/etc/needrestart/conf.d/99-devbox-paseo.conf}"
 VSCODE_REQUIRED_FILE="${DEVBOX_VSCODE_REQUIRED_FILE:-/var/lib/devbox-runtime/vscode-required}"
 VSCODE_SUCCESS_FILE="${DEVBOX_VSCODE_SUCCESS_FILE:-/var/lib/devbox-runtime/vscode-installed}"
 VSCODE_BIN="${DEVBOX_VSCODE_BIN:-/usr/bin/code}"
@@ -99,6 +100,34 @@ require_env() {
 }
 
 require_env
+
+ensure_needrestart_paseo_protection() {
+  local config_dir tmp
+  config_dir="$(dirname "$NEEDRESTART_PASEO_CONFIG_FILE")"
+
+  install -d -m 0755 "$config_dir"
+  tmp="$(mktemp "$config_dir/.99-devbox-paseo.conf.XXXXXX")"
+  if ! printf '%s\n' \
+      '# Managed by devbox-toolchain. Keep live agents attached during package upgrades.' \
+      '$nrconf{override_rc}{qr(^paseo\.service$)} = 0;' > "$tmp" \
+      || ! chmod 0644 "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+
+  if [ -f "$NEEDRESTART_PASEO_CONFIG_FILE" ] \
+      && cmp -s "$tmp" "$NEEDRESTART_PASEO_CONFIG_FILE"; then
+    rm -f "$tmp"
+    echo "needrestart: paseo.service already protected"
+    return 0
+  fi
+
+  if ! mv -f "$tmp" "$NEEDRESTART_PASEO_CONFIG_FILE"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  echo "needrestart: protected paseo.service from package-triggered restarts"
+}
 
 install_if_changed() {
   local src="$1"
@@ -393,7 +422,7 @@ ensure_npm_global_version() {
 # /usr/bin on the dev's PATH, so a broken file there shadows every other copy
 # and a presence-only gate would let it wedge the box forever.
 claude_contract_version() {
-  local resolved version
+  local minimum_version="2.1.255" resolved version version_number
 
   # -f follows symlinks: a symlink to a regular file passes, a directory fails.
   [ -f "$CLAUDE_BIN" ] || return 1
@@ -408,6 +437,10 @@ claude_contract_version() {
     HOME="$DEV_HOME" \
     "$CLAUDE_BIN" --version 2>/dev/null)" || return 1
   [ -n "$version" ] || return 1
+  version_number="${version%% *}"
+  [[ "$version_number" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+  [ "$(printf '%s\n' "$minimum_version" "$version_number" | sort -V | head -1)" = "$minimum_version" ] \
+    || return 1
 
   printf '%s\n' "$version"
 }
@@ -1092,10 +1125,24 @@ ensure_agent_plugins() {
         https://github.com/openai/codex-plugin-cc.git --scope user
     sudo -u "$DEV_USER" -H env HOME="$DEV_HOME" \
       "$CLAUDE_BIN" plugin install codex@openai-codex --scope user
-    # openai-curated is Codex's preconfigured official marketplace
-    # (github.com/openai/plugins), which carries superpowers — no
-    # `plugin marketplace add`, and never the author's personal repo
-    # (obra/superpowers): every source here must be a vendor-org channel.
+  )
+
+  # Codex supplies its reserved openai-curated marketplace only to an
+  # authenticated session. A new box has Codex installed before the developer
+  # signs in, so leave the retry marker armed without failing convergence.
+  if ! (
+    cd "$DEV_HOME"
+    sudo -u "$DEV_USER" -H env HOME="$DEV_HOME" \
+      "$CODEX_BIN" login status >/dev/null 2>&1
+  ); then
+    echo "agent-plugins: Claude plugins installed; waiting for Codex login"
+    return 0
+  fi
+
+  (
+    cd "$DEV_HOME"
+    # Never use the author's personal repo (obra/superpowers): this source
+    # must remain Codex's authenticated, vendor-owned marketplace.
     sudo -u "$DEV_USER" -H env HOME="$DEV_HOME" \
       "$CODEX_BIN" plugin add superpowers@openai-curated
   )
@@ -1278,6 +1325,7 @@ run_tool() {
   fi
 }
 
+ensure_needrestart_paseo_protection
 run_tool base-tools ensure_base_tools
 run_tool tailscale ensure_tailscale_package
 run_tool gh ensure_gh

--- a/scripts/gcp/devbox-bedrock-config
+++ b/scripts/gcp/devbox-bedrock-config
@@ -26,8 +26,9 @@
 #   - agents.providers.bclaude           (merged into ~/.paseo/config.json,
 #                                         registering bclaude as a selectable
 #                                         Paseo agent; GATED on the same claude
-#                                         success marker, and takes effect only
-#                                         after a dev-initiated daemon restart)
+#                                         success marker, then live-reloaded
+#                                         without restarting the daemon when
+#                                         its CLI supports reload)
 # NO-OP when the manifest has no .bedrock object — plumbing lands first.
 # Never touches ~/.claude/settings.json.
 set -euo pipefail
@@ -43,6 +44,7 @@ CLAUDE_SUCCESS_FILE="${DEVBOX_CLAUDE_SUCCESS_FILE:-/var/lib/devbox-runtime/claud
 CLAUDE_BIN="${DEVBOX_CLAUDE_BIN:-$DEV_HOME/.local/bin/claude}"
 BCLAUDE_BIN="${DEVBOX_BCLAUDE_BIN:-/usr/local/bin/bclaude}"
 BDCC_BIN="${DEVBOX_BDCC_BIN:-/usr/local/bin/bdcc}"
+PASEO_BIN="${DEVBOX_PASEO_BIN:-$DEV_HOME/.local/bin/paseo}"
 PASEO_CONFIG_FILE="${DEVBOX_PASEO_CONFIG_FILE:-$DEV_HOME/.paseo/config.json}"
 
 # Every inherited variable that could select a different principal or bypass
@@ -80,6 +82,14 @@ dev_owner="$(stat -c %U "$DEV_HOME" 2>/dev/null || echo dev)"
 install_as_dev() { # path mode content-file
   install -m "$2" "$3" "$1" 2>/dev/null || { cp "$3" "$1"; chmod "$2" "$1"; }
   chown "$dev_owner:$dev_owner" "$1" 2>/dev/null || true
+}
+
+run_as_dev() {
+  if [ "${DEVBOX_SKIP_ROOT_CHECK:-0}" = 1 ]; then
+    HOME="$DEV_HOME" "$@"
+  else
+    sudo -u "$dev_owner" -H env HOME="$DEV_HOME" "$@"
+  fi
 }
 
 # ----- 1. /etc/devbox/bedrock.json -----
@@ -415,6 +425,27 @@ else
         chown "$dev_owner:$dev_owner" "$tmp_paseo" 2>/dev/null || true
         chmod 0600 "$tmp_paseo"
         mv -f "$tmp_paseo" "$PASEO_CONFIG_FILE"
+      fi
+      # No temporary config should survive a failed CLI/help/reload command.
+      rm -f "$tmp_paseo"
+      # Paseo keeps provider configuration in memory. Newer CLIs can reload
+      # without restarting active agents; the supported 0.4 bootstrap pin
+      # predates that command and keeps its existing restart-based behavior.
+      if [ -x "$PASEO_BIN" ]; then
+        if ! paseo_help="$(run_as_dev "$PASEO_BIN" --help)"; then
+          echo "devbox-bedrock-config: failed to inspect Paseo CLI capabilities" >&2
+          exit 1
+        fi
+        if grep -qE '^[[:space:]]+reload([[:space:]]|$)' <<< "$paseo_help"; then
+          # Retry even unchanged renders so a previously failed reload is
+          # repaired on the next converge. Actual reload errors stay fatal.
+          if ! run_as_dev "$PASEO_BIN" reload --json >/dev/null; then
+            echo "devbox-bedrock-config: failed to reload Paseo daemon config" >&2
+            exit 1
+          fi
+        else
+          echo "WARN: installed Paseo has no reload command; restart Paseo to load provider changes" >&2
+        fi
       fi
     else
       echo "devbox-bedrock-config: paseo provider render failed validation; config left unchanged" >&2

--- a/scripts/gcp/devbox-observability
+++ b/scripts/gcp/devbox-observability
@@ -9,6 +9,7 @@ OPS_AGENT_VERSION="${DEVBOX_OPS_AGENT_VERSION:-}"
 CONFIG="${DEVBOX_OPS_AGENT_CONFIG:-/etc/google-cloud-ops-agent/config.yaml}"
 STATE_DIR="${DEVBOX_RUNTIME_STATE_DIR:-/var/lib/devbox-runtime}"
 VERSION_MARKER="$STATE_DIR/ops-agent.version"
+APT_SOURCE_DIR="${DEVBOX_APT_SOURCE_DIR:-/etc/apt/sources.list.d}"
 
 if [ "${DEVBOX_SKIP_ROOT_CHECK:-0}" != 1 ] && [ "$(id -u)" -ne 0 ]; then
   echo "FATAL: run as root" >&2
@@ -23,22 +24,39 @@ fi
 install -d -m 0755 "$STATE_DIR"
 export DEBIAN_FRONTEND=noninteractive
 
+ops_agent_package_matches_pin() {
+  local installed
+  installed="$(dpkg-query -W -f='${db:Status-Status} ${Version}' google-cloud-ops-agent 2>/dev/null)" \
+    || return 1
+  # Debian distro/build suffixes belong to the pinned upstream release;
+  # another release sharing its prefix (e.g. 2.70.01) does not.
+  [[ "$installed" == "installed $OPS_AGENT_VERSION" \
+    || "$installed" == "installed $OPS_AGENT_VERSION"[~+-]* ]]
+}
+
 package_changed=false
 if [ "${DEVBOX_SKIP_APT:-0}" != 1 ]; then
-  if [ ! -f "$VERSION_MARKER" ] || [ "$(cat "$VERSION_MARKER")" != "$OPS_AGENT_VERSION" ] \
-     || ! dpkg-query -W google-cloud-ops-agent >/dev/null 2>&1; then
-    if [ ! -f /etc/apt/sources.list.d/google-cloud-ops-agent.list ]; then
+  if ! ops_agent_package_matches_pin; then
+    # A failed repair must not leave stale bookkeeping claiming success.
+    rm -f "$VERSION_MARKER"
+    if [ ! -f "$APT_SOURCE_DIR/google-cloud-ops-agent.list" ]; then
       curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
         | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
       echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt google-cloud-ops-agent-noble-all main" \
-        > /etc/apt/sources.list.d/google-cloud-ops-agent.list
+        > "$APT_SOURCE_DIR/google-cloud-ops-agent.list"
     fi
     apt-get update
     apt-get install -y --allow-downgrades "google-cloud-ops-agent=${OPS_AGENT_VERSION}*"
-    printf '%s\n' "$OPS_AGENT_VERSION" > "$VERSION_MARKER"
+    if ! ops_agent_package_matches_pin; then
+      echo "FATAL: google-cloud-ops-agent is not installed at requested version $OPS_AGENT_VERSION after installation" >&2
+      exit 1
+    fi
     package_changed=true
   else
     echo "ops-agent package: already converged"
+  fi
+  if [ ! -f "$VERSION_MARKER" ] || [ "$(cat "$VERSION_MARKER")" != "$OPS_AGENT_VERSION" ]; then
+    printf '%s\n' "$OPS_AGENT_VERSION" > "$VERSION_MARKER"
   fi
 else
   # Test seam: emulate package convergence bookkeeping only.

--- a/tests/devbox-bedrock-config-test.sh
+++ b/tests/devbox-bedrock-config-test.sh
@@ -12,6 +12,25 @@ work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work/state" "$work/home" "$work/etc" \
   "$work/usr/local/bin" "$work/home/.local/bin"
+cat > "$work/home/.local/bin/paseo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$*" = --help ]; then
+  [ "${DEVBOX_TEST_PASEO_HELP_FAIL:-0}" != 1 ] || exit 1
+  if [ "${DEVBOX_TEST_PASEO_LEGACY:-0}" = 1 ]; then
+    printf 'Commands:\n  daemon [options]  Manage the daemon\n'
+  else
+    printf 'Commands:\n  reload [options]  Reload the daemon configuration\n'
+  fi
+  exit 0
+fi
+[ "$*" = 'reload --json' ] || exit 2
+[ "${DEVBOX_TEST_PASEO_LEGACY:-0}" != 1 ] || exit 2
+printf '%s\n' "$*" >> "$DEVBOX_TEST_PASEO_LOG"
+[ "${DEVBOX_TEST_PASEO_RELOAD_FAIL:-0}" != 1 ] || exit 1
+printf '{"appliedPaths":["agents.providers.bclaude"],"restartRequiredPaths":[],"overrideControlledPaths":[]}\n'
+EOF
+chmod +x "$work/home/.local/bin/paseo"
 
 run_concern() {
   DEVBOX_RUNTIME_STATE_DIR="$work/state" \
@@ -22,7 +41,9 @@ run_concern() {
   DEVBOX_CLAUDE_BIN="$work/home/.local/bin/claude" \
   DEVBOX_BCLAUDE_BIN="$work/usr/local/bin/bclaude" \
   DEVBOX_BDCC_BIN="$work/usr/local/bin/bdcc" \
+  DEVBOX_PASEO_BIN="$work/home/.local/bin/paseo" \
   DEVBOX_PASEO_CONFIG_FILE="$work/home/.paseo/config.json" \
+  DEVBOX_TEST_PASEO_LOG="$work/paseo.log" \
   DEVBOX_SKIP_ROOT_CHECK=1 \
   bash "$CONCERN"
 }
@@ -532,6 +553,8 @@ JSON
 chmod 0600 "$work/home/.paseo/config.json"
 : > "$work/state/claude-code-installed"
 run_concern >/dev/null
+[ "$(cat "$work/paseo.log")" = "reload --json" ] \
+  || fail "Paseo daemon config was not reloaded after provider render"
 
 cfg="$work/home/.paseo/config.json"
 jq -e '.agents.providers.bclaude.extends == "claude"' "$cfg" >/dev/null \
@@ -635,8 +658,33 @@ jq -e '.agents.providers.bclaude | keys
 
 echo "== paseo provider: idempotent"
 before="$(cat "$cfg")"
+reloads_before="$(wc -l < "$work/paseo.log")"
 run_concern >/dev/null
 [ "$before" = "$(cat "$cfg")" ] || fail "second run changed the paseo config"
+[ "$(wc -l < "$work/paseo.log")" -eq "$((reloads_before + 1))" ] \
+  || fail "an unchanged valid provider render must retry the non-restarting Paseo reload"
+
+echo "== paseo provider: older CLIs keep the documented restart behavior"
+reloads_before="$(wc -l < "$work/paseo.log")"
+if ! legacy_out="$(DEVBOX_TEST_PASEO_LEGACY=1 run_concern 2>&1)"; then
+  fail "a supported older Paseo without reload must still converge its config"
+fi
+rg -q --fixed-strings 'restart Paseo to load provider changes' <<<"$legacy_out" \
+  || fail "older Paseo must report that its provider changes need a restart"
+[ "$(wc -l < "$work/paseo.log")" -eq "$reloads_before" ] \
+  || fail "older Paseo must not receive an unsupported reload command"
+
+echo "== paseo provider: help/reload failures are fatal and clean up temporary configs"
+for failure_mode in DEVBOX_TEST_PASEO_HELP_FAIL DEVBOX_TEST_PASEO_RELOAD_FAIL; do
+  if (export "$failure_mode=1"; run_concern) >"$work/paseo-failure.log" 2>&1; then
+    fail "$failure_mode must fail the concern"
+  fi
+  if compgen -G "$work/home/.paseo/.config.json.*" >/dev/null; then
+    fail "$failure_mode leaked a temporary provider config"
+  fi
+  [ "$before" = "$(cat "$cfg")" ] || fail "$failure_mode corrupted the saved config"
+done
+run_concern >/dev/null || fail "provider reload must recover on the next successful run"
 
 echo "== paseo provider: absent config is skipped, malformed is refused"
 rm -f "$cfg"

--- a/tests/devbox-toolchain-test.sh
+++ b/tests/devbox-toolchain-test.sh
@@ -329,6 +329,26 @@ case "$*" in
     shift 3
     "$@"
     ;;
+  *"${CODEX_BIN:-/__unset_codex__} login status"*)
+    if [ "$#" -ne 8 ] \
+        || [ "$1" != -u ] \
+        || [ "$2" != "$DEV_USER" ] \
+        || [ "$3" != -H ] \
+        || [ "$4" != env ] \
+        || [ "$5" != "HOME=$DEV_HOME" ] \
+        || [ "$6" != "$CODEX_BIN" ] \
+        || [ "$7" != login ] \
+        || [ "$8" != status ]; then
+      echo "Codex login check did not use the expected dev-user boundary: $*" >&2
+      exit 1
+    fi
+    if [ "$PWD" != "$DEV_HOME" ]; then
+      echo "Codex login check did not start from the dev home: cwd=$PWD expected=$DEV_HOME" >&2
+      exit 1
+    fi
+    shift 5
+    "$@"
+    ;;
   *" plugin "*)
     if [ "$#" -lt 7 ] \
         || [ "$1" != -u ] \
@@ -468,6 +488,7 @@ cat > "$fake_bin/codex" <<'EOF'
 #!/usr/bin/env bash
 command="codex $*"
 echo "$command" >> "$DEVBOX_TEST_PLUGIN_LOG"
+[ "$command" != "codex login status" ] || [ "${DEVBOX_TEST_CODEX_NOT_LOGGED_IN:-0}" != 1 ] || exit 1
 [ "${DEVBOX_TEST_PLUGIN_FAIL_COMMAND:-}" != "$command" ]
 EOF
   cat > "$fake_bin/tailscale" <<'EOF'
@@ -718,9 +739,10 @@ run_agent_plugins_step() {
   local function_file="$workdir/ensure-agent-plugins.sh"
 
   extract_agent_plugins_step "$function_file"
-  DEVBOX_TEST_LOG="$workdir/commands.log" \
+    DEVBOX_TEST_LOG="$workdir/commands.log" \
     DEVBOX_TEST_PLUGIN_LOG="$workdir/plugin.log" \
     DEVBOX_TEST_PLUGIN_FAIL_COMMAND="${DEVBOX_TEST_PLUGIN_FAIL_COMMAND:-}" \
+    DEVBOX_TEST_CODEX_NOT_LOGGED_IN="${DEVBOX_TEST_CODEX_NOT_LOGGED_IN:-0}" \
     DEV_USER="$test_user" \
     DEV_HOME="$workdir/home" \
     GCP_RUNTIME_BUCKET_FILE="$workdir/etc/devbox/runtime-bucket" \
@@ -863,6 +885,7 @@ test_matching_versions_are_noop() {
     DEVBOX_PASEO_SYSTEM_BIN="$workdir/usr/local/bin/paseo" \
     DEVBOX_PASEO_CONFIG_DIR="$workdir/home/.paseo" \
     DEVBOX_PASEO_CONFIG_FILE="$workdir/home/.paseo/config.json" \
+    DEVBOX_NEEDRESTART_PASEO_CONFIG_FILE="$workdir/etc/needrestart/conf.d/99-devbox-paseo.conf" \
     DEVBOX_VSCODE_REQUIRED_FILE="$workdir/var/lib/devbox-runtime/vscode-required" \
     DEVBOX_VSCODE_SUCCESS_FILE="$workdir/var/lib/devbox-runtime/vscode-installed" \
     DEVBOX_VSCODE_BIN="$workdir/fake-bin/code" \
@@ -966,6 +989,7 @@ test_containerd_migration() {
     DEVBOX_PASEO_SYSTEM_BIN="$workdir/usr/local/bin/paseo" \
     DEVBOX_PASEO_CONFIG_DIR="$workdir/home/.paseo" \
     DEVBOX_PASEO_CONFIG_FILE="$workdir/home/.paseo/config.json" \
+    DEVBOX_NEEDRESTART_PASEO_CONFIG_FILE="$workdir/etc/needrestart/conf.d/99-devbox-paseo.conf" \
     DEVBOX_VSCODE_REQUIRED_FILE="$workdir/var/lib/devbox-runtime/vscode-required" \
     DEVBOX_VSCODE_SUCCESS_FILE="$workdir/var/lib/devbox-runtime/vscode-installed" \
     DEVBOX_VSCODE_BIN="$workdir/fake-bin/code" \
@@ -1038,7 +1062,7 @@ test_agent_plugins_new_gcp_bootstrap_and_post_success_noop() {
   run_agent_plugins_step "$workdir"
 
   mapfile -t commands < "$workdir/plugin.log"
-  [ "${#commands[@]}" -eq 5 ] || fail "new GCP bootstrap did not run all five plugin commands"
+  [ "${#commands[@]}" -eq 6 ] || fail "new GCP bootstrap did not run all six plugin commands"
   [ "${commands[0]}" = "claude plugin marketplace add https://github.com/anthropics/claude-plugins-official.git --scope user" ] \
     || fail "Claude official marketplace was not added at user scope"
   [ "${commands[1]}" = "claude plugin install superpowers@claude-plugins-official --scope user" ] \
@@ -1047,8 +1071,10 @@ test_agent_plugins_new_gcp_bootstrap_and_post_success_noop() {
     || fail "OpenAI Codex marketplace was not added to Claude Code"
   [ "${commands[3]}" = "claude plugin install codex@openai-codex --scope user" ] \
     || fail "Codex plugin was not installed for Claude Code"
-  [ "${commands[4]}" = "codex plugin add superpowers@openai-curated" ] \
-    || fail "Superpowers was not installed for Codex from the preconfigured official marketplace"
+  [ "${commands[4]}" = "codex login status" ] \
+    || fail "Codex authentication was not checked before official marketplace use"
+  [ "${commands[5]}" = "codex plugin add superpowers@openai-curated" ] \
+    || fail "Superpowers was not installed for Codex from the official marketplace"
   if grep -q 'obra/superpowers' "$workdir/plugin.log"; then
     fail "Codex Superpowers must come from openai-curated, not a personal marketplace clone"
   fi
@@ -1060,8 +1086,38 @@ test_agent_plugins_new_gcp_bootstrap_and_post_success_noop() {
   mkdir -p "$workdir/var/lib/devbox-bootstrap"
   : > "$workdir/var/lib/devbox-bootstrap/complete"
   run_agent_plugins_step "$workdir"
-  [ "$(wc -l < "$workdir/plugin.log")" -eq 5 ] \
+  [ "$(wc -l < "$workdir/plugin.log")" -eq 6 ] \
     || fail "plugin commands reran after successful provisioning"
+}
+
+test_agent_plugins_defers_codex_until_login_without_failing() {
+  local workdir
+  workdir="$(mktemp -d)"
+  trap 'rm -rf "$workdir"' RETURN
+
+  make_fake_bin "$workdir/fake-bin"
+  mkdir -p "$workdir/home" "$workdir/etc/devbox" "$workdir/var/lib/devbox-runtime"
+  : > "$workdir/etc/devbox/runtime-bucket"
+  : > "$workdir/var/lib/devbox-runtime/codex-cli-installed"
+  : > "$workdir/var/lib/devbox-runtime/claude-code-installed"
+
+  DEVBOX_TEST_CODEX_NOT_LOGGED_IN=1 run_agent_plugins_step "$workdir"
+  [ "$(wc -l < "$workdir/plugin.log")" -eq 5 ] \
+    || fail "logged-out bootstrap did not stop after the Codex login check"
+  ! grep -qF "codex plugin add" "$workdir/plugin.log" \
+    || fail "logged-out bootstrap attempted to install from the unavailable official marketplace"
+  [ -e "$workdir/var/lib/devbox-runtime/agent-plugins-required" ] \
+    || fail "logged-out bootstrap did not retain its retry marker"
+  [ ! -e "$workdir/var/lib/devbox-runtime/agent-plugins-installed" ] \
+    || fail "logged-out bootstrap created a false success marker"
+
+  run_agent_plugins_step "$workdir"
+  [ "$(wc -l < "$workdir/plugin.log")" -eq 11 ] \
+    || fail "plugin provisioning did not retry after Codex login"
+  [ ! -e "$workdir/var/lib/devbox-runtime/agent-plugins-required" ] \
+    || fail "successful post-login retry did not clear its marker"
+  [ -e "$workdir/var/lib/devbox-runtime/agent-plugins-installed" ] \
+    || fail "successful post-login retry did not create its marker"
 }
 
 test_agent_plugins_skip_existing_gcp_and_aws() {
@@ -1123,7 +1179,7 @@ test_agent_plugins_wait_for_codex_and_retry_after_bootstrap() {
   mkdir -p "$workdir/var/lib/devbox-bootstrap"
   : > "$workdir/var/lib/devbox-bootstrap/complete"
   run_agent_plugins_step "$workdir"
-  [ "$(wc -l < "$workdir/plugin.log")" -eq 9 ] \
+  [ "$(wc -l < "$workdir/plugin.log")" -eq 10 ] \
     || fail "plugin provisioning did not stop at failure and retry all idempotent commands"
   [ ! -e "$workdir/var/lib/devbox-runtime/agent-plugins-required" ] \
     || fail "successful plugin retry did not clear retry marker"
@@ -2340,16 +2396,20 @@ run_claude_contract() {
 }
 
 # Writes a stub claude at $1 whose --version behaviour is chosen by $2:
-#   ok    -> exits 0, prints a version
-#   empty -> exits 0, prints nothing
-#   fail  -> exits 3
+#   ok      -> exits 0, prints a current version
+#   minimum -> exits 0, prints the minimum Fable 5.1-compatible version
+#   old     -> exits 0, prints the version immediately below the minimum
+#   empty   -> exits 0, prints nothing
+#   fail    -> exits 3
 make_stub_claude() {
   local path="$1" mode="$2"
   mkdir -p "$(dirname "$path")"
   case "$mode" in
-    ok)    printf '#!/bin/sh\nprintf "2.9.9 (Claude Code)\\n"\n' > "$path" ;;
-    empty) printf '#!/bin/sh\nexit 0\n' > "$path" ;;
-    fail)  printf '#!/bin/sh\nexit 3\n' > "$path" ;;
+    ok)      printf '#!/bin/sh\nprintf "2.9.9 (Claude Code)\\n"\n' > "$path" ;;
+    minimum) printf '#!/bin/sh\nprintf "2.1.255 (Claude Code)\\n"\n' > "$path" ;;
+    old)     printf '#!/bin/sh\nprintf "2.1.254 (Claude Code)\\n"\n' > "$path" ;;
+    empty)   printf '#!/bin/sh\nexit 0\n' > "$path" ;;
+    fail)    printf '#!/bin/sh\nexit 3\n' > "$path" ;;
     *)     fail "unknown stub mode: $mode" ;;
   esac
   chmod 0755 "$path"
@@ -2365,6 +2425,31 @@ test_claude_contract_accepts_a_good_binary() {
   out="$(run_claude_contract "$workdir")" || fail "contract rejected a good binary"
   [ "$out" = "2.9.9 (Claude Code)" ] \
     || fail "contract did not print the version: $out"
+}
+
+test_claude_contract_accepts_the_fable_5_1_minimum_version() {
+  local workdir out
+  workdir="$(mktemp -d)"
+  trap 'rm -rf "$workdir"' RETURN
+  make_fake_bin "$workdir/fake-bin"
+  make_stub_claude "$workdir/home/.local/bin/claude" minimum
+
+  out="$(run_claude_contract "$workdir")" \
+    || fail "contract rejected the minimum Fable 5.1-compatible Claude Code"
+  [ "$out" = "2.1.255 (Claude Code)" ] \
+    || fail "contract did not print the minimum compatible version: $out"
+}
+
+test_claude_contract_rejects_a_pre_fable_5_1_version() {
+  local workdir
+  workdir="$(mktemp -d)"
+  trap 'rm -rf "$workdir"' RETURN
+  make_fake_bin "$workdir/fake-bin"
+  make_stub_claude "$workdir/home/.local/bin/claude" old
+
+  if run_claude_contract "$workdir" >/dev/null 2>&1; then
+    fail "contract accepted Claude Code older than Fable 5.1 requires"
+  fi
 }
 
 test_claude_contract_rejects_a_directory() {
@@ -2787,7 +2872,34 @@ test_require_env_fails_closed_without_the_pin_env() {
   done
 }
 
+test_needrestart_defers_paseo_before_package_work() {
+  local function_file protect_line tools_line workdir
+  workdir="$(mktemp -d)"
+  trap 'rm -rf "$workdir"' RETURN
+  function_file="$workdir/ensure-needrestart.sh"
+
+  awk '/^ensure_needrestart_paseo_protection\(\)/,/^}$/' \
+    "$repo_root/scripts/devbox-toolchain" > "$function_file"
+  [ -s "$function_file" ] || fail "ensure_needrestart_paseo_protection not found"
+
+  NEEDRESTART_PASEO_CONFIG_FILE="$workdir/etc/needrestart/conf.d/99-devbox-paseo.conf" \
+    bash -c 'set -euo pipefail; source "$1"; ensure_needrestart_paseo_protection' \
+      _ "$function_file"
+
+  grep -qxF '$nrconf{override_rc}{qr(^paseo\.service$)} = 0;' \
+    "$workdir/etc/needrestart/conf.d/99-devbox-paseo.conf" \
+    || fail "needrestart config does not defer paseo.service"
+
+  protect_line="$(grep -n '^ensure_needrestart_paseo_protection$' \
+    "$repo_root/scripts/devbox-toolchain" | cut -d: -f1)"
+  tools_line="$(grep -n '^run_tool base-tools ' \
+    "$repo_root/scripts/devbox-toolchain" | cut -d: -f1)"
+  [ -n "$protect_line" ] && [ "$protect_line" -lt "$tools_line" ] \
+    || fail "Paseo protection is not installed before package convergence"
+}
+
 test_require_env_fails_closed_without_the_pin_env
+test_needrestart_defers_paseo_before_package_work
 test_paseo_new_gcp_bootstrap_installs_pinned_tarball_and_writes_tailnet_config
 test_paseo_tarball_download_failure_retains_retry_marker
 test_paseo_tarball_sha_mismatch_retains_retry_marker
@@ -2821,6 +2933,7 @@ test_vscode_launcher_install_failure_keeps_marker_and_cleans_tmp
 test_vscode_success_marker_repairs_missing_launcher
 test_vscode_launcher_stops_when_tailscale_serve_fails
 test_agent_plugins_new_gcp_bootstrap_and_post_success_noop
+test_agent_plugins_defers_codex_until_login_without_failing
 test_agent_plugins_skip_existing_gcp_and_aws
 test_agent_plugins_wait_for_codex_and_retry_after_bootstrap
 test_agent_plugins_wait_for_claude
@@ -2833,6 +2946,8 @@ test_tmux_plugins_fetch_failure_fails_and_leaves_conf_alone
 test_matching_versions_are_noop
 test_containerd_migration
 test_claude_contract_accepts_a_good_binary
+test_claude_contract_accepts_the_fable_5_1_minimum_version
+test_claude_contract_rejects_a_pre_fable_5_1_version
 test_claude_contract_rejects_a_directory
 test_claude_contract_rejects_non_executable
 test_claude_contract_rejects_wrong_owner

--- a/tests/gcp-observability-test.sh
+++ b/tests/gcp-observability-test.sh
@@ -41,4 +41,113 @@ if DEVBOX_OPS_AGENT_CONFIG="$work/config.yaml" DEVBOX_RUNTIME_STATE_DIR="$work/s
   fail "must fail when DEVBOX_OPS_AGENT_VERSION is unset"
 fi
 
+# Exercise real package reconciliation with fake system commands. The version
+# marker must never substitute for dpkg's installed version or package status.
+mkdir -p "$work/bin" "$work/apt"
+touch "$work/apt/google-cloud-ops-agent.list"
+cat > "$work/bin/dpkg-query" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ -f "$OBS_TEST_WORK/package-version" ] || exit 1
+if [ "$#" -eq 2 ]; then exit 0; fi
+printf '%s %s\n' "$(cat "$OBS_TEST_WORK/package-status")" "$(cat "$OBS_TEST_WORK/package-version")"
+EOF
+cat > "$work/bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$OBS_TEST_WORK/apt-calls"
+if [ "$1" = install ]; then
+  [ "${OBS_TEST_INSTALL_FAIL:-0}" != 1 ] || exit 42
+  if [ "${OBS_TEST_INSTALL_NOOP:-0}" != 1 ]; then
+    printf '%s\n' "${OBS_TEST_INSTALL_VERSION:-2.70.0~ubuntu24.04}" > "$OBS_TEST_WORK/package-version"
+    printf 'installed\n' > "$OBS_TEST_WORK/package-status"
+  fi
+fi
+EOF
+# Package tests use a fixture repo and must never download a signing key.
+cat > "$work/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+echo 'unexpected repository bootstrap' >&2
+exit 1
+EOF
+cat > "$work/bin/gpg" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+cat > "$work/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$OBS_TEST_WORK/systemctl-calls"
+EOF
+chmod +x "$work/bin/"*
+
+run_package_obs() {
+  PATH="$work/bin:$PATH" \
+  OBS_TEST_WORK="$work" \
+  DEVBOX_OPS_AGENT_VERSION="2.70.0" \
+  DEVBOX_OPS_AGENT_CONFIG="$work/config.yaml" \
+  DEVBOX_RUNTIME_STATE_DIR="$work/state" \
+  DEVBOX_APT_SOURCE_DIR="$work/apt" \
+  DEVBOX_SKIP_ROOT_CHECK=1 \
+  bash "$OBS"
+}
+
+reset_package_fixture() {
+  printf '%s\n' "$1" > "$work/package-version"
+  printf '%s\n' "${2:-installed}" > "$work/package-status"
+  printf '2.70.0\n' > "$work/state/ops-agent.version"
+  : > "$work/apt-calls"
+  : > "$work/systemctl-calls"
+}
+
+# Reproduce a marker that claims convergence after an out-of-band upgrade.
+reset_package_fixture '2.71.0~ubuntu24.04'
+run_package_obs >/dev/null
+rg -q --fixed-strings 'install -y --allow-downgrades google-cloud-ops-agent=2.70.0*' "$work/apt-calls" \
+  || fail "a matching marker must not hide installed package drift"
+[ "$(cat "$work/package-version")" = '2.70.0~ubuntu24.04' ] \
+  || fail "drifted package must be reconciled"
+rg -q --fixed-strings 'restart google-cloud-ops-agent' "$work/systemctl-calls" \
+  || fail "a changed package must restart the agent"
+
+# Missing or stale bookkeeping is repaired without reinstalling a correct
+# package or restarting its service. Exact versions and distro suffixes work.
+for installed_version in '2.70.0' '2.70.0~ubuntu24.04' '2.70.0-1' '2.70.0+build1'; do
+  reset_package_fixture "$installed_version"
+  rm "$work/state/ops-agent.version"
+  run_package_obs >/dev/null
+  [ ! -s "$work/apt-calls" ] || fail "a missing marker must not reinstall a correct package"
+  [ ! -s "$work/systemctl-calls" ] || fail "marker repair must not restart the agent"
+  [ "$(cat "$work/state/ops-agent.version")" = '2.70.0' ] || fail "marker must be repaired"
+done
+reset_package_fixture '2.70.0~ubuntu24.04'
+printf '2.55.0\n' > "$work/state/ops-agent.version"
+run_package_obs >/dev/null
+[ ! -s "$work/apt-calls" ] || fail "a stale marker must not reinstall a correct package"
+[ ! -s "$work/systemctl-calls" ] || fail "a stale marker must not restart the agent"
+[ "$(cat "$work/state/ops-agent.version")" = '2.70.0' ] || fail "stale marker must be repaired"
+
+# Removed packages can remain in dpkg's database, and version-prefix matches
+# must not accept another release such as 2.70.01.
+reset_package_fixture '2.70.0~ubuntu24.04' 'config-files'
+run_package_obs >/dev/null
+[ -s "$work/apt-calls" ] || fail "a removed package must be reinstalled"
+reset_package_fixture '2.70.01~ubuntu24.04'
+run_package_obs >/dev/null
+[ -s "$work/apt-calls" ] || fail "the version match must respect release boundaries"
+reset_package_fixture '2.70.0~ubuntu24.04'
+rm "$work/package-version"
+run_package_obs >/dev/null
+[ -s "$work/apt-calls" ] || fail "a missing package must be installed"
+
+# Apt success alone cannot justify a success marker. Failures leave the
+# marker absent and do not report a successful package/service reconciliation.
+for failure_mode in OBS_TEST_INSTALL_FAIL OBS_TEST_INSTALL_NOOP; do
+  reset_package_fixture '2.55.0~ubuntu24.04'
+  if (export "$failure_mode=1"; run_package_obs) >"$work/failure.log" 2>&1; then
+    fail "$failure_mode must fail package reconciliation"
+  fi
+  [ ! -e "$work/state/ops-agent.version" ] || fail "a failed repair must invalidate the version marker"
+  [ ! -s "$work/systemctl-calls" ] || fail "a failed repair must not claim a successful restart"
+done
+
 echo "PASS: gcp-observability-test"

--- a/tests/gcp-runtime-test.sh
+++ b/tests/gcp-runtime-test.sh
@@ -84,14 +84,14 @@ fi
 
 [ -f "$VARIABLES" ] || fail "gcp/variables.tf missing"
 for expected_pin in \
-  'ANTHROPIC_MODEL[[:space:]]*=[[:space:]]*"anthropic\.claude-fable-5\[1m\]"' \
-  'ANTHROPIC_DEFAULT_FABLE_MODEL[[:space:]]*=[[:space:]]*"global\.anthropic\.claude-fable-5\[1m\]"' \
+  'ANTHROPIC_MODEL[[:space:]]*=[[:space:]]*"global\.anthropic\.claude-fable-5-1\[1m\]"' \
+  'ANTHROPIC_DEFAULT_FABLE_MODEL[[:space:]]*=[[:space:]]*"global\.anthropic\.claude-fable-5-1\[1m\]"' \
   'ANTHROPIC_DEFAULT_OPUS_MODEL[[:space:]]*=[[:space:]]*"global\.anthropic\.claude-opus-5\[1m\]"'; do
   rg -q "$expected_pin" "$VARIABLES" \
-    || fail "Claude Bedrock Fable and Opus pins must request 1M context"
+    || fail "Claude Bedrock Fable 5.1 and Opus pins must request 1M context"
 done
 for expected_picker_model in \
-  'anthropic\.claude-fable-5\[1m\]' \
+  'global\.anthropic\.claude-fable-5-1\[1m\]' \
   'global\.anthropic\.claude-fable-5\[1m\]' \
   'global\.anthropic\.claude-opus-5\[1m\]'; do
   rg -q "^[[:space:]]*\"${expected_picker_model}\",[[:space:]]*$" "$VARIABLES" \
@@ -99,6 +99,9 @@ for expected_picker_model in \
   [ "$(rg -c "^[[:space:]]*\"${expected_picker_model}\",[[:space:]]*$" "$VARIABLES")" -eq 1 ] \
     || fail "Claude Bedrock picker must contain exactly one ${expected_picker_model} entry"
 done
+if rg -q 'CLAUDE_CODE_USE_MANTLE|"anthropic\.claude-fable-5\[1m\]"' "$VARIABLES"; then
+  fail "fleet Bedrock defaults must use inference profiles, not Mantle or bare Fable model ids"
+fi
 bedrock_available_models_default="$(
   awk '
     /^variable "bedrock_available_models"/ { in_picker = 1 }


### PR DESCRIPTION
Six devboxes were running uncommitted runtime changes while the promoted fleet manifest still carried older Bedrock settings. This records the Fable 5.1 defaults, Claude minimum version, authenticated Codex plugin deferral, and Paseo restart protection, with capability-aware provider reloads that repair stale daemon configuration.

Ops Agent convergence now checks the installed package instead of trusting its version marker, verifies repairs before recording success, and avoids reinstalling a correct package. The example version advances to 2.70.0; rollout remains candidate → canary → promotion.

Validation: all 20 shell test scripts, all 9 GCP Terraform tests, both Terraform root validations, and git diff --check passed. Regression coverage includes stale package markers, failed installs, legacy Paseo CLIs, and reload failures.
